### PR TITLE
Settings grafana dashboard error

### DIFF
--- a/src/main/java/com/takipi/integrations/grafana/input/EnvironmentsInput.java
+++ b/src/main/java/com/takipi/integrations/grafana/input/EnvironmentsInput.java
@@ -11,6 +11,6 @@ package com.takipi.integrations.grafana.input;
 * Screenshot: https://drive.google.com/file/d/187V1IuD5PeC9cz9sd4nzpY12q2PxpmW9/view?usp=sharing
 *
 */
-public class EnvironmentsInput extends VariableInput {
+public class EnvironmentsInput extends BaseEnvironmentsInput {
 	
 }


### PR DESCRIPTION
Getting the settings results in an exception because the input environments variable is not properly converted from inputs.